### PR TITLE
Allow forked repos as push targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,16 +51,18 @@ Run with `--dry-run` flag to only print the summary and don't make any changes.
 Usage: gitlab-mirror-maker [OPTIONS]
 
 Options:
-  --version                 Show the version and exit.
-  --github-token TEXT       GitHub authentication token  [required]
-  --gitlab-token TEXT       GitLab authentication token  [required]
-  --github-user TEXT        GitHub username. If not provided, your GitLab
-                            username will be used by default.
+  --version                       Show the version and exit.
+  --github-token TEXT             GitHub authentication token  [required]
+  --gitlab-token TEXT             GitLab authentication token  [required]
+  --github-user TEXT              GitHub username. If not provided, your
+                                  GitLab username will be used by default.
 
-  --dry-run / --no-dry-run  If enabled, a summary will be printed and no
-                            mirrors will be created.
+  --target-forks / --no-target-forks
+                                  Allow forks as target repos for pushing.
+  --dry-run / --no-dry-run        If enabled, a summary will be printed and no
+                                  mirrors will be created.
 
-  --help                    Show this message and exit.
+  --help                          Show this message and exit.
 ```
 
 # How it works?

--- a/mirrormaker/github.py
+++ b/mirrormaker/github.py
@@ -6,6 +6,8 @@ token = ''
 # GitHub username (under this user namespace the mirrors will be created)
 user = ''
 
+target_forks = False
+
 
 def get_repos():
     """Finds all public GitHub repositories (which are not forks) of authenticated user.
@@ -23,8 +25,8 @@ def get_repos():
     except requests.exceptions.RequestException as e:
         raise SystemExit(e)
 
-    # Return only non forked repositories
-    return [x for x in r.json() if not x['fork']]
+    # Return only non forked repositories unless target_forks is set
+    return [x for x in r.json() if not x['fork'] or target_forks]
 
 
 def repo_exists(github_repos, repo_slug):

--- a/mirrormaker/mirrormaker.py
+++ b/mirrormaker/mirrormaker.py
@@ -11,11 +11,14 @@ from . import github
 @click.option('--github-token', required=True, help='GitHub authentication token')
 @click.option('--gitlab-token', required=True, help='GitLab authentication token')
 @click.option('--github-user', help='GitHub username. If not provided, your GitLab username will be used by default.')
+@click.option('--target-forks/--no-target-forks', default=False, help="Allow forks as target repos for pushing.")
 @click.option('--dry-run/--no-dry-run', default=False, help="If enabled, a summary will be printed and no mirrors will be created.")
-def mirrormaker(github_token, gitlab_token, github_user, dry_run):
+def mirrormaker(github_token, gitlab_token, github_user, target_forks,
+dry_run):
     github.token = github_token
     github.user = github_user
     gitlab.token = gitlab_token
+    github.target_forks = target_forks
 
     click.echo('Getting your public GitLab repositories')
     gitlab_repos = gitlab.get_repos()


### PR DESCRIPTION
Sometimes you want to allow forked repos as push targets for mirrors, e.g. when the repo you fork from is a mirror, too, so the "fork" status is visible on both GitLab and GitHub:

```
GitLab:                GitHub:

original ---mirror---> original_mirror
  |                        |
 fork                     fork
  |                        |
  v                        v
 fork ------mirror---> fork_mirror
```

This PR implements a CLI switch `--target-forks` that allows this.