### PR TITLE
Allow specifying single repo to mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,16 @@ Run with `--dry-run` flag to only print the summary and don't make any changes.
 ### Full synopsis
 
 ```
-Usage: gitlab-mirror-maker [OPTIONS]
+Usage: gitlab-mirror-maker [OPTIONS] [REPO]
+
+  Set up mirroring of repositories from GitLab to GitHub.
+
+  By default, mirrors for all repositories owned by the user will be set up.
+
+  If the REPO argument is given, a mirror will be set up for that repository
+  only. REPO can be either a simple project name ("myproject"), in which
+  case its namespace is assumed to be the current user, or the path of a
+  project under a specific namespace ("mynamespace/myproject").
 
 Options:
   --version                 Show the version and exit.

--- a/mirrormaker/gitlab.py
+++ b/mirrormaker/gitlab.py
@@ -11,7 +11,7 @@ def get_repos():
      - List of public GitLab repositories.
     """
 
-    url = f'https://gitlab.com/api/v4/projects?visibility=public&owned=true&archived=false'
+    url = 'https://gitlab.com/api/v4/projects?visibility=public&owned=true&archived=false'
     headers = {'Authorization': f'Bearer {token}'}
 
     try:
@@ -21,6 +21,41 @@ def get_repos():
         raise SystemExit(e)
 
     return r.json()
+
+
+def get_user():
+    url = 'https://gitlab.com/api/v4/user'
+    headers = {'Authorization': f'Bearer {token}'}
+
+    try:
+        r = requests.get(url, headers=headers)
+        r.raise_for_status()
+    except requests.exceptions.RequestException as e:
+        raise SystemExit(e)
+
+    return r.json()
+
+
+def get_repo_by_shorthand(shorthand):
+    if "/" not in shorthand:
+        user = get_user()["username"]
+        namespace, project = user, shorthand
+    else:
+        namespace, project = shorthand.rsplit("/", maxsplit=1)
+
+    project_id = requests.utils.quote("/".join([namespace, project]), safe="")
+
+    url = f'https://gitlab.com/api/v4/projects/{project_id}'
+    headers = {'Authorization': f'Bearer {token}'}
+
+    try:
+        r = requests.get(url, headers=headers)
+        r.raise_for_status()
+    except requests.exceptions.RequestException as e:
+        raise SystemExit(e)
+
+    return r.json()
+
 
 
 def get_mirrors(gitlab_repo):

--- a/mirrormaker/mirrormaker.py
+++ b/mirrormaker/mirrormaker.py
@@ -12,16 +12,30 @@ from . import github
 @click.option('--gitlab-token', required=True, help='GitLab authentication token')
 @click.option('--github-user', help='GitHub username. If not provided, your GitLab username will be used by default.')
 @click.option('--dry-run/--no-dry-run', default=False, help="If enabled, a summary will be printed and no mirrors will be created.")
-def mirrormaker(github_token, gitlab_token, github_user, dry_run):
+@click.argument('repo', required=False)
+def mirrormaker(github_token, gitlab_token, github_user, dry_run, repo=None):
+    """
+    Set up mirroring of repositories from GitLab to GitHub.
+
+    By default, mirrors for all repositories owned by the user will be set up.
+
+    If the REPO argument is given, a mirror will be set up for that repository
+    only. REPO can be either a simple project name ("myproject"), in which case
+    its namespace is assumed to be the current user, or the path of a project
+    under a specific namespace ("mynamespace/myproject").
+    """
     github.token = github_token
     github.user = github_user
     gitlab.token = gitlab_token
 
-    click.echo('Getting your public GitLab repositories')
-    gitlab_repos = gitlab.get_repos()
-    if not gitlab_repos:
-        click.echo('There are no public repositories in your GitLab account.')
-        return
+    if repo:
+        gitlab_repos = [gitlab.get_repo_by_shorthand(repo)]
+    else:
+        click.echo('Getting your public GitLab repositories')
+        gitlab_repos = gitlab.get_repos()
+        if not gitlab_repos:
+            click.echo('There are no public repositories in your GitLab account.')
+            return
 
     click.echo('Getting your public GitHub repositories')
     github_repos = github.get_repos()


### PR DESCRIPTION
This PR adds an optional `REPO` argument to the CLI so that users can conveniently create a mirror for just a single repository instead of for all of them. I'd say this use case is common enough that this should be the first positional argument instead of an option.